### PR TITLE
Changed git commit command to single quotes

### DIFF
--- a/tcr.mjs
+++ b/tcr.mjs
@@ -15,7 +15,7 @@ function test() {
 
 function commit() {
   console.log("Tests passed -> Commit changes");
-  execSync(logCommand("git commit --all --message='tcr: tests pass'"), {
+  execSync(logCommand('git commit --all --message="tcr: tests pass"'), {
     stdio: "inherit",
   });
 }


### PR DESCRIPTION
On Windows, single quotes are not allowed on the command line. This change will assure that the app does work on the most common platforms. 